### PR TITLE
Implement default payment option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "magento2-module",
   "require": {
     "paynl/magento2-plugin": "^3.5",
-    "hyva-themes/magento2-hyva-checkout": "^1.1"
+    "hyva-themes/magento2-hyva-checkout": "^1.1.6"
   },
   "support": {
     "email": "support@pay.nl",

--- a/src/Plugin/SetDefaultPaymentMethod.php
+++ b/src/Plugin/SetDefaultPaymentMethod.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paynl\HyvaCheckout\Plugin;
+
+use Hyva\Checkout\Magewire\Checkout\Payment\MethodList;
+use Magento\Checkout\Model\Session as SessionCheckout;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Paynl\Payment\Helper\PayHelper;
+use Paynl\Payment\Model\Config;
+
+class SetDefaultPaymentMethod
+{
+    private Config $config;
+    private SessionCheckout $sesionCheckout;
+    private CartRepositoryInterface $cartRepository;
+    private PayHelper $payHelper;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(
+        Config $config,
+        SessionCheckout $sessionCheckout,
+        CartRepositoryInterface $cartRepository,
+        PayHelper $payHelper
+    ) {
+        $this->config = $config;
+        $this->sessionCheckout = $sessionCheckout;
+        $this->cartRepository = $cartRepository;
+        $this->payHelper = $payHelper;
+    }
+
+    /**
+     * @param MethodList $subject
+     * @return void
+     */
+    public function afterMount(MethodList $subject): void
+    {
+        if (!$subject->method && ($defaultOption = $this->config->getDefaultPaymentOption())) {
+            try {
+                $quote = $this->sessionCheckout->getQuote();
+                $method = $quote->getPayment()->setMethod($defaultOption);
+                $this->cartRepository->save($quote);
+                $subject->method = $defaultOption;
+            } catch (LocalizedException $e) {
+                $this->payHelper->logNotice('PAY. Hyva Checkout: Failed to set default payment method on quote ' . $quote->getId() .'. Reason: ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/src/Plugin/SetDefaultPaymentMethod.php
+++ b/src/Plugin/SetDefaultPaymentMethod.php
@@ -37,7 +37,7 @@ class SetDefaultPaymentMethod
      * @param MethodList $subject
      * @return void
      */
-    public function afterMount(MethodList $subject): void
+    public function afterBoot(MethodList $subject): void
     {
         if (!$subject->method && ($defaultOption = $this->config->getDefaultPaymentOption())) {
             try {

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -12,4 +12,7 @@
     <type name="Hyva\Checkout\Model\MethodMetaDataInterface">
         <plugin name="paynl_hyva_checkout_handle_payment_method_icons" type="Paynl\HyvaCheckout\Plugin\HandlePaymentMethodIcons"/>
     </type>
+    <type name="Hyva\Checkout\Magewire\Checkout\Payment\MethodList">
+        <plugin name="paynl_hyva_checkout_set_default_method" type="Paynl\HyvaCheckout\Plugin\SetDefaultPaymentMethod" />
+    </type>
 </config>


### PR DESCRIPTION
Add support for the `payment/paynl/default_payment_option` setting in the Hyva Checkout.

Minimal hyva checkout version: 1.1.6
on versions below 1.1.6 the afterBoot does not work and should be renamed to afterMount