### PR TITLE
Update kvknummer and vatnummer fields to match Pay extension >= 3.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "PAY. Payment methods for Magento 2 with Hyva Checkout Compatability",
   "type": "magento2-module",
   "require": {
-    "paynl/magento2-plugin": "^3.5",
+    "paynl/magento2-plugin": "^3.8.3",
     "hyva-themes/magento2-hyva-checkout": "^1.1.22"
   },
   "support": {

--- a/src/Magewire/Checkout/Payment/Method/GenericPaynlMethod.php
+++ b/src/Magewire/Checkout/Payment/Method/GenericPaynlMethod.php
@@ -21,8 +21,8 @@ use Rakit\Validation\Validator;
 class GenericPaynlMethod extends Form implements EvaluationInterface
 {
     public ?string $instructions = null;
-    public ?string $kvknummer = null;
-    public ?string $vatnummer = null;
+    public ?string $cocnumber = null;
+    public ?string $vatnumber = null;
     public ?string $dateofbirth = null;
     public ?bool $billinkAgree = null;
 
@@ -69,12 +69,12 @@ class GenericPaynlMethod extends Form implements EvaluationInterface
             $this->dateofbirth = $dob;
         }
 
-        if ($kvk = $quote->getPayment()->getAdditionalInformation('kvknummer')) {
-            $this->kvknummer = $kvk;
+        if ($coc = $quote->getPayment()->getAdditionalInformation('cocnumber')) {
+            $this->cocnumber = $coc;
         }
 
-        if ($vat = $quote->getPayment()->getAdditionalInformation('vatnummer')) {
-            $this->vatnummer = $vat;
+        if ($vat = $quote->getPayment()->getAdditionalInformation('vatnumber')) {
+            $this->vatnumber = $vat;
         }
 
         if ($billink = $quote->getPayment()->getAdditionalInformation('billink_agree')) {
@@ -116,12 +116,12 @@ class GenericPaynlMethod extends Form implements EvaluationInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function updatedKvknummer(?string $value): ?string
+    public function updatedCocnumber(?string $value): ?string
     {
         $value = empty($value) ? null : $value;
 
         $quote = $this->getQuote();
-        $quote->getPayment()->setAdditionalInformation('kvknummer', $value);
+        $quote->getPayment()->setAdditionalInformation('cocnumber', $value);
         $this->quoteRepository->save($quote);
 
         return $value;
@@ -133,12 +133,12 @@ class GenericPaynlMethod extends Form implements EvaluationInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function updatedVatnummer(?string $value): ?string
+    public function updatedVatnumber(?string $value): ?string
     {
         $value = empty($value) ? null : $value;
 
         $quote = $this->getQuote();
-        $quote->getPayment()->setAdditionalInformation('vatnummer', $value);
+        $quote->getPayment()->setAdditionalInformation('vatnumber', $value);
         $this->quoteRepository->save($quote);
 
         return $value;
@@ -183,14 +183,14 @@ class GenericPaynlMethod extends Form implements EvaluationInterface
                     ->withMessage((string) __('You must first agree to the payment terms.'));
             }
 
-            if (strlen((string) $this->kvknummer) < 8) {
+            if (strlen((string) $this->cocnumber) < 8) {
                 return $resultFactory->createErrorMessageEvent()
                     ->withCustomEvent('payment:method:error')
                     ->withMessage((string) __('Enter a valid COC number'));
             }
         }
 
-        if ($vatRequired && strlen((string) $this->vatnummer) < 8) {
+        if ($vatRequired && strlen((string) $this->vatnumber) < 8) {
             return $resultFactory->createErrorMessageEvent()
                 ->withCustomEvent('payment:method:error')
                 ->withMessage((string) __('Enter a valid VAT-id'));

--- a/src/view/frontend/templates/component/payment/method/generic_paynl_method.phtml
+++ b/src/view/frontend/templates/component/payment/method/generic_paynl_method.phtml
@@ -26,15 +26,15 @@ $magewire->registerMethodCode($block->getData('method_code'));
 
     <?php if ($magewire->showKVK()): ?>
         <div class="relative text-sm mb-4">
-            <label class="-top-[10px] left-[10px] absolute bg-[#fafafa] px-1" for="kvknummer"><?= $escaper->escapeHtml(__('COC number')) ?></label>
-            <input wire:model.delay.750ms="kvknummer" class="border border-[#c2c2c2] px-3 py-4 rounded-md bg-transparent text-sm w-full" type="text" id="kvknummer" name="kvknummer" placeholder="xxxxxxxx"/>
+            <label class="-top-[10px] left-[10px] absolute bg-[#fafafa] px-1" for="cocnumber"><?= $escaper->escapeHtml(__('COC number')) ?></label>
+            <input wire:model.delay.750ms="cocnumber" class="border border-[#c2c2c2] px-3 py-4 rounded-md bg-transparent text-sm w-full" type="text" id="cocnumber" name="cocnumber" placeholder="xxxxxxxx"/>
         </div>
     <?php endif; ?>
 
     <?php if ($magewire->showVAT()): ?>
         <div class="relative text-sm mb-4">
             <label class="-top-[10px] left-[10px] absolute bg-[#fafafa] px-1" for="vatnumber"><?= $escaper->escapeHtml(__('VAT-id')) ?></label>
-            <input wire:model.delay.750ms="vatnummer" class="border border-[#c2c2c2] px-3 py-4 rounded-md bg-transparent text-sm w-full" type="text" id="vatnumber" name="vatnumber" placeholder="xxxxxxxxxxxxxx"/>
+            <input wire:model.delay.750ms="vatnumber" class="border border-[#c2c2c2] px-3 py-4 rounded-md bg-transparent text-sm w-full" type="text" id="vatnumber" name="vatnumber" placeholder="xxxxxxxxxxxxxx"/>
         </div>
     <?php endif; ?>
 


### PR DESCRIPTION
The billink payment method was no longer sending the COC number.

Upon investigation of the Paynl extension, I noticed that some fields were renamed in https://github.com/paynl/magento2-plugin/commit/6a2162920d388e96ea462c47c6f9e1ab97acd6e5

This pull requests updates the Hyva checkout module to be compatible with the renamed fields.