### PR TITLE
paylink checkout_active support and icons for 2 new methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "PAY. Payment methods for Magento 2 with Hyva Checkout Compatability",
   "type": "magento2-module",
   "require": {
-    "paynl/magento2-plugin": "^3.8.3",
+    "paynl/magento2-plugin": "^3.16.1",
     "hyva-themes/magento2-hyva-checkout": "^1.1.22"
   },
   "support": {

--- a/src/Plugin/PaymentMethodFilter.php
+++ b/src/Plugin/PaymentMethodFilter.php
@@ -79,6 +79,11 @@ class PaymentMethodFilter
             return false;
         }
 
+        // as of v3.16.0 of main pay extension, checkoutActive is only implemented for paylink
+        if (!$method->getCheckoutActive() && $method->getCode() === 'paynl_payment_paylink') {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/view/frontend/layout/hyva_checkout_components.xml
+++ b/src/view/frontend/layout/hyva_checkout_components.xml
@@ -704,6 +704,29 @@
                     </argument>
                 </arguments>
             </block>
+            <block name="checkout.payment.method.paynl_payment_huisdierencadeaukaart" as="paynl_payment_huisdierencadeaukaart"
+                   template="Paynl_HyvaCheckout::component/payment/method/generic_paynl_method.phtml">
+                <arguments>
+                    <argument name="magewire" xsi:type="object">
+                        Paynl\HyvaCheckout\Magewire\Checkout\Payment\Method\GenericPaynlMethod
+                    </argument>
+                    <argument name="method_code" xsi:type="string">paynl_payment_huisdierencadeaukaart</argument>
+                    <argument name="metadata" xsi:type="array">
+                        <item name="icon" xsi:type="array">
+                            <item name="src" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconUrl">
+                                <param name="methodCode">paynl_payment_huisdierencadeaukaart</param>
+                            </item>
+                            <item name="attributes" xsi:type="array">
+                                <item name="width" xsi:type="string">35px</item>
+                                <item name="loading" xsi:type="string">lazy</item>
+                                <item name="alt" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconAltText">
+                                    <param name="methodCode">paynl_payment_huisdierencadeaukaart</param>
+                                </item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
             <block name="checkout.payment.method.paynl_payment_huisentuincadeau" as="paynl_payment_huisentuincadeau"
                    template="Paynl_HyvaCheckout::component/payment/method/generic_paynl_method.phtml">
                 <arguments>
@@ -951,6 +974,29 @@
                                 <item name="loading" xsi:type="string">lazy</item>
                                 <item name="alt" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconAltText">
                                     <param name="methodCode">paynl_payment_multibanco</param>
+                                </item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
+            <block name="checkout.payment.method.paynl_payment_nationaletuinbon" as="paynl_payment_nationaletuinbon"
+                   template="Paynl_HyvaCheckout::component/payment/method/generic_paynl_method.phtml">
+                <arguments>
+                    <argument name="magewire" xsi:type="object">
+                        Paynl\HyvaCheckout\Magewire\Checkout\Payment\Method\GenericPaynlMethod
+                    </argument>
+                    <argument name="method_code" xsi:type="string">paynl_payment_nationaletuinbon</argument>
+                    <argument name="metadata" xsi:type="array">
+                        <item name="icon" xsi:type="array">
+                            <item name="src" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconUrl">
+                                <param name="methodCode">paynl_payment_nationaletuinbon</param>
+                            </item>
+                            <item name="attributes" xsi:type="array">
+                                <item name="width" xsi:type="string">35px</item>
+                                <item name="loading" xsi:type="string">lazy</item>
+                                <item name="alt" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconAltText">
+                                    <param name="methodCode">paynl_payment_nationaletuinbon</param>
                                 </item>
                             </item>
                         </item>

--- a/src/view/frontend/layout/hyva_checkout_components.xml
+++ b/src/view/frontend/layout/hyva_checkout_components.xml
@@ -1118,6 +1118,29 @@
                     </argument>
                 </arguments>
             </block>
+            <block name="checkout.payment.method.paynl_payment_paylink" as="paynl_payment_paylink"
+                   template="Paynl_HyvaCheckout::component/payment/method/generic_paynl_method.phtml">
+                <arguments>
+                    <argument name="magewire" xsi:type="object">
+                        Paynl\HyvaCheckout\Magewire\Checkout\Payment\Method\GenericPaynlMethod
+                    </argument>
+                    <argument name="method_code" xsi:type="string">paynl_payment_paylink</argument>
+                    <argument name="metadata" xsi:type="array">
+                        <item name="icon" xsi:type="array">
+                            <item name="src" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconUrl">
+                                <param name="methodCode">paynl_payment_paylink</param>
+                            </item>
+                            <item name="attributes" xsi:type="array">
+                                <item name="width" xsi:type="string">35px</item>
+                                <item name="loading" xsi:type="string">lazy</item>
+                                <item name="alt" xsi:type="helper" helper="Paynl\HyvaCheckout\Helper\PaymentIcon::getIconAltText">
+                                    <param name="methodCode">paynl_payment_paylink</param>
+                                </item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
             <block name="checkout.payment.method.paynl_payment_paypal" as="paynl_payment_paypal"
                    template="Paynl_HyvaCheckout::component/payment/method/generic_paynl_method.phtml">
                 <arguments>


### PR DESCRIPTION
Added support for some new features introduced in the mainline Pay extension: 

- Added payment icon and checkout_active implementation for the paynl_payment_paylink introduced in v3.16.0
- Added payment icon for paynl_payment_huisdierencadeaukaart and paynl_payment_nationaletuinbon introduced in v3.16.1. This should fix https://github.com/paynl/magento2-hyva-checkout/issues/14