### PR TITLE
Change orderData parameter to nullable type

### DIFF
--- a/src/Model/Magewire/Payment/PlaceOrderService.php
+++ b/src/Model/Magewire/Payment/PlaceOrderService.php
@@ -27,7 +27,7 @@ class PlaceOrderService extends AbstractPlaceOrderService
         CartManagementInterface $cartManagement,
         QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId,
         PayHelper $payHelper,
-        AbstractOrderData $orderData = null
+        ?AbstractOrderData $orderData = null
     ) {
         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
         $this->payHelper = $payHelper;


### PR DESCRIPTION
Fix  for https://github.com/paynl/magento2-hyva-checkout/issues/22

PHP8.4 

Paynl\HyvaCheckout\Model\Magewire\Payment\PlaceOrderService::__construct(): Implicitly marking parameter $orderData as nullable is deprecated, the explicit nullable type must be used instead in /home/user/domains/www.example.nl/public_html/vendor/paynl/magento2-hyva-checkout/src/Model/Magewire/Payment/PlaceOrderService.php on line 26 {"exception":"[object] (Exception(code: 0): Deprecated Functionality: Paynl\\HyvaCheckout\\Model\\Magewire\\Payment\\PlaceOrderService::__construct(): Implicitly marking parameter $orderData as nullable is deprecated, the explicit nullable type must be used instead in /home/user/domains/www.example.nl/public_html/vendor/paynl/magento2-hyva-checkout/src/Model/Magewire/Payment/PlaceOrderService.php on line 26 at /home/user/domains/www.example.nl/public_html/vendor/magento/framework/App/ErrorHandler.php:61)"}